### PR TITLE
Add basic test (+ pytest) instead of adhoc code in .travis.yml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__
+.cache

--- a/.tests/test_load.py
+++ b/.tests/test_load.py
@@ -1,0 +1,14 @@
+from pathlib import Path
+
+data_dir = Path(__file__).parent.parent
+
+
+def test_at_least_one_event_present():
+    # This loads the DB, making sure it *can* be loaded
+    from pyvodb.load import get_db
+    from pyvodb.tables import Event
+    db = get_db(str(data_dir))
+    cnt = db.query(Event).count()
+    print(cnt)
+    if not cnt:
+        exit("no events found")

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,15 +8,6 @@ install:
   - pip install pytest
 
 script:
-  # This loads the DB, making sure it *can* be loaded
-  - |
-      python -c '
-      from pyvodb.load import get_db
-      from pyvodb.tables import Event
-      db=get_db(".")
-      cnt=db.query(Event).count()
-      print(cnt)
-      if not cnt:
-          exit("no events found")'
+  - py.test -v .tests
 
 sudo: false


### PR DESCRIPTION
Aby se to dalo aspoň nějak rozumně testovat ručně, aby se daly snadněji odhalit problémy jako třeba v #12 .

Název adresáře s testy musí začínat tečkou, protože pyvodb si stěžuje na jakékoli cizí soubory (co nejsou README nebo něco s tečkou). To není úplně nejlepší návrh.