### PR TITLE
Add super old Brno Pyvo info from Facebook events

### DIFF
--- a/series/brno-pyvo/events/2011-04-26-poprve.yaml
+++ b/series/brno-pyvo/events/2011-04-26-poprve.yaml
@@ -6,3 +6,4 @@ venue: cafe-falk
 talks: []
 urls:
 - http://lanyrd.com/2011/pyvo-april/
+- https://www.facebook.com/events/196576713713338/

--- a/series/brno-pyvo/events/2011-06-13-druhe.yaml
+++ b/series/brno-pyvo/events/2011-06-13-druhe.yaml
@@ -6,3 +6,4 @@ venue: kaverna
 talks: []
 urls:
 - http://lanyrd.com/2011/pyvo-june/
+- https://www.facebook.com/events/178935428828137/

--- a/series/brno-pyvo/events/2011-09-05-prvni-pondeli-po-prazdninach.yaml
+++ b/series/brno-pyvo/events/2011-09-05-prvni-pondeli-po-prazdninach.yaml
@@ -6,3 +6,4 @@ venue: kaverna
 talks: []
 urls:
 - http://lanyrd.com/2011/pyvo-september/
+- https://www.facebook.com/events/232475156798546/

--- a/series/brno-pyvo/events/2011-10-03-podzimni-poprazdninove.yaml
+++ b/series/brno-pyvo/events/2011-10-03-podzimni-poprazdninove.yaml
@@ -6,3 +6,4 @@ venue: kaverna
 talks: []
 urls:
 - http://lanyrd.com/2011/pyvo-october/
+- https://www.facebook.com/events/173703669376237/

--- a/series/brno-pyvo/events/2011-11-07-listopadove.yaml
+++ b/series/brno-pyvo/events/2011-11-07-listopadove.yaml
@@ -6,3 +6,4 @@ venue: kaverna
 talks: []
 urls:
 - http://lanyrd.com/2011/pyvo-november/
+- https://www.facebook.com/events/194048420671473/

--- a/series/brno-pyvo/events/2012-01-27-nosql.yaml
+++ b/series/brno-pyvo/events/2012-01-27-nosql.yaml
@@ -13,3 +13,4 @@ talks:
   - slides: https://speakerdeck.com/u/encukou/p/povidani-o-sqlalchemy
 urls:
 - http://lanyrd.com/2012/pyvo-january/
+- https://www.facebook.com/events/266397403422488/

--- a/series/brno-pyvo/events/2012-03-26-breznove.yaml
+++ b/series/brno-pyvo/events/2012-03-26-breznove.yaml
@@ -6,3 +6,4 @@ venue: kaverna
 talks: []
 urls:
 - http://lanyrd.com/2012/pyvo-march/
+- https://www.facebook.com/events/197931570315648/

--- a/series/brno-pyvo/events/2012-04-27-punkove.yaml
+++ b/series/brno-pyvo/events/2012-04-27-punkove.yaml
@@ -3,6 +3,19 @@ start: 2012-04-27
 name: Brněnské PyVo
 topic: Punkové
 venue: kaverna
+description: |
+  Na PyVo v dubnu. Téma: Python WTFs, hacks, tips & tricks. Přispějte každý
+  svým příběhem! Program tohoto PyVa je ryze punkový a živelný.
+
+  Ale s tvými geek slajdy, Jocho, počítám! ;-)
+
+  Srazy.info: http://pojd.me/1qm
+
+  Poznámka: Facebook je debil. Když uděláte event pro skupinu, nikdo jiný než
+  členové se na něj nepřihlásí, i když je to Open Group. Přitom to dřív šlo.
+  Takže na tento event se přihlásí jen členové Pyonýrů, což nebylo záměrem.
+  Přijďte prosímvás kdokoliv. Máte-li nutkání se přihlásit, udělejte to na
+  srazy.info.
 talks:
 - title: Trocha pythonové magie
   speakers:
@@ -13,3 +26,5 @@ talks:
   - video: http://www.youtube.com/watch?v=EF3dxcGn6to
 urls:
 - http://lanyrd.com/2012/pyvo-april/
+- https://www.facebook.com/events/256834891079598/
+- https://twitter.com/naPyVo/status/192622779647016961

--- a/series/brno-pyvo/events/2012-09-27-nebezpecne.yaml
+++ b/series/brno-pyvo/events/2012-09-27-nebezpecne.yaml
@@ -39,3 +39,4 @@ talks:
   - slides: https://speakerdeck.com/u/spaze/p/pyvo2012-michalspacek-bezpecnost-notes
 urls:
 - http://lanyrd.com/2012/pyvo-september/
+- https://www.facebook.com/events/444292668942770/

--- a/series/brno-pyvo/events/2012-10-25-deployment.yaml
+++ b/series/brno-pyvo/events/2012-10-25-deployment.yaml
@@ -35,3 +35,4 @@ talks:
   - video: http://www.youtube.com/watch?v=gignh1ZNXpQ
 urls:
 - http://lanyrd.com/2012/pyvo-october/
+- https://www.facebook.com/events/366769300072423/

--- a/series/brno-pyvo/events/2012-11-29-cli.yaml
+++ b/series/brno-pyvo/events/2012-11-29-cli.yaml
@@ -25,3 +25,4 @@ talks:
   - video: http://www.youtube.com/watch?v=Rzkv2uwjXAU
 urls:
 - http://lanyrd.com/2012/pyvo-november/
+- https://www.facebook.com/events/373704196044634/


### PR DESCRIPTION
I've added everything what's left. Some links are not even accessible anymore (Facebook probably expires very very old events).

Closes https://github.com/pyvec/zapojse/issues/26