### PR TITLE
Add support for ISO639-1 language tags to schema, add some examples

### DIFF
--- a/schema.yaml
+++ b/schema.yaml
@@ -170,6 +170,14 @@ properties:
                                 $ref: '#/definitions/uri'
                         lightning:
                           const: true
+                        language:
+                          type: object
+                          additionalProperties: false
+                          properties:
+                            slides:
+                              $ref: '#/definitions/language-code'
+                            audio:
+                              $ref: '#/definitions/language-code'
                       required:
                         - title
                   topic:
@@ -234,3 +242,10 @@ definitions:
   uri:
     type: string
     format: uri
+  language-code:
+    type: string
+    pattern: '^[a-zA-Z]{2,3}([-\/][a-zA-Z]{2,3})?$'
+    examples:
+    - "cs"
+    - "en"
+    - "sk"

--- a/series/brno-pyvo/events/2018-01-25.yaml
+++ b/series/brno-pyvo/events/2018-01-25.yaml
@@ -35,6 +35,9 @@ talks:
         nebo jak založit vlastní komunitní kurz či workshop.
 
     urls: []
+    language:
+      slides: en
+      audio: cs
     coverage:
     - video: https://www.youtube.com/watch?v=oZ1ChUrjiCY
 
@@ -53,6 +56,9 @@ talks:
         [Želví grafika]: http://www.albatrosmedia.cz/tituly/40005210/zelvi-grafika/
 
     urls: []
+    language:
+      slides: cs
+      audio: cs
     coverage:
     - video: https://www.youtube.com/watch?v=IY8udbQHNRg
 
@@ -62,6 +68,9 @@ talks:
     description: |
         Michal představí [Python víkendy s kiwi.com](https://pythonvikend.kiwi.com/).
     urls: []
+    language:
+      slides: en
+      audio: cs
     coverage:
     - video: https://www.youtube.com/watch?v=41xf99oSsB4
 
@@ -69,6 +78,9 @@ talks:
     speakers: []
     description: ""
     urls: []
+    language:
+      slides: en
+      audio: cs
     coverage:
     - video: https://www.youtube.com/watch?v=m2fJ27FnBtk
 
@@ -78,6 +90,8 @@ talks:
     lightning: true
     description: ""
     urls: []
+    language:
+      audio: cs
     coverage:
     - video: https://www.youtube.com/watch?v=zDExJKYHLOc
 

--- a/series/brno-pyvo/events/2018-02-22.yaml
+++ b/series/brno-pyvo/events/2018-02-22.yaml
@@ -26,6 +26,9 @@ talks:
         vizuální programování – od definice problému přes návrh grafického
         rozhraní a expresivitu jazyka až po implementaci a škálování v Pythonu.
 
+    language:
+      slides: en
+      audio: en
     coverage:
       - video: https://www.youtube.com/watch?v=lMFnJ0ZZvNw
 
@@ -43,6 +46,9 @@ talks:
         orchestrovaných pomocou OpenShift či Kubernetes schopných spracovať
         „big data“.
 
+    language:
+      slides: en
+      audio: en
     coverage:
       - video: https://www.youtube.com/watch?v=AtgKsKrGDwg
 

--- a/series/brno-pyvo/events/2018-03-29.yaml
+++ b/series/brno-pyvo/events/2018-03-29.yaml
@@ -15,7 +15,9 @@ talks:
         - Moisés Guimarães
     description: |
         In this presentation we will talk about how to bring that C library we [like|need|depend on] into Python so we can code in Python everyday! \o/
-    urls: []
+    language:
+      slides: en
+      audio: en
     coverage:
     - video: https://www.youtube.com/watch?v=OoyYjpry-h4
     - slides: http://mguimaraes.org/talks/events/pyvo-2018-03


### PR DESCRIPTION
Přidání jazyka slajdů/výkladu do metadat. Na pyvo.cz ani v pyvodb se to ještě nijak neprojeví, ale to snad přidávání neblokuje.

Je otázka jestli stačí jeden jazyk nebo je jich potřeba víc, případně jestli by bylo je vhodné označit některé talky za "bezjazyčné" (např. obrázkové slajdy nebo úplně bez slajdů). Kdyžtak řekni, schéma se dá upravit.