### PR TITLE
Olomouc: Remove virtual venue

### DIFF
--- a/cities/olomouc/venues/online.yaml
+++ b/cities/olomouc/venues/online.yaml
@@ -1,8 +1,0 @@
-city: Olomouc
-name: OloPyvo
-address: 123 Elf Road, North Pole, 88888
-location:
-  latitude: '90.0000000'
-  longitude: '0.0000000'
-notes:
-  '[>>> Vstup do našeho salónku ZDE <<<](https://meet.vpsfree.cz/OloPyvo)'

--- a/series/olomouc-pyvo/events/2021-01-27-prvni-onlajnovo-olopyvo.yaml
+++ b/series/olomouc-pyvo/events/2021-01-27-prvni-onlajnovo-olopyvo.yaml
@@ -9,9 +9,10 @@ description: |
     nepotřebností takového systému a my se co nejdříve zase budeme
     scházet naživo!
 
+    Připojte se na [meet.vpsfree.cz/OloPyvo](https://meet.vpsfree.cz/OloPyvo).
+
     Těšíme se na vás! <3
 
-venue: online
 talks:
   - title: Jak vám Python může šetřit čas
     speakers:

--- a/series/olomouc-pyvo/events/2021-02-24-python-backend-v-seznam-cz.yaml
+++ b/series/olomouc-pyvo/events/2021-02-24-python-backend-v-seznam-cz.yaml
@@ -6,9 +6,10 @@ description: |
     Ze svými vývojářskými zkušenostmi kolem Python technologií se
     rozhodl podělit team lead Petr Stehlík ze společnosti Seznam.cz.
 
+    Připojte se na [meet.vpsfree.cz/OloPyvo](https://meet.vpsfree.cz/OloPyvo).
+
     Těšíme se na všechny!
 
-venue: online
 talks:
   - title: Dev stack backendu v televizeseznam.cz
     speakers:


### PR DESCRIPTION
Funguje to líp s odkazem v textu, bez klubovny na severním pólu.