### PR TITLE
Fix links in historical descriptions

### DIFF
--- a/series/brno-pyvo/events/2018-09-27.yaml
+++ b/series/brno-pyvo/events/2018-09-27.yaml
@@ -15,7 +15,7 @@ talks:
         How do we find the good free videos on the topics we are interested in,
         and avoid the junk?
 
-        [PythonLinks.info](PythonLinks.info) organize Python-related videos
+        [PythonLinks.info](https://PythonLinks.info) organize Python-related videos
         into a tree of categories.
         It rates each video based on upvotes versus total votes.
         Swipe left, right, up, or down to browse the tree. 

--- a/series/brno-pyvo/events/2018-12-13.yaml
+++ b/series/brno-pyvo/events/2018-12-13.yaml
@@ -26,7 +26,7 @@ description: |
     [by](https://pyvo.cz/brno-pyvo/2014-12/
     )[lo](https://pyvo.cz/brno-pyvo/2015-12/)
     [už](https://pyvo.cz/brno-pyvo/2016-12/)
-    [šest](https://pyvo.cz/brno-pyvo/2017-12).
+    [šest](https://pyvo.cz/brno-pyvo/2017-12/).
 
     Máte doma nepoužívaný router, diody, sluchátka, disky, nebo jinou
     elektroniku? Nebo se nehodil úlovek z loňska?


### PR DESCRIPTION
- 2018-12-13: The slash-less URL redirects to one with a trailing slash
- 2018-09-27: `https://` was missing, making this a relative link